### PR TITLE
Update lambda function

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,8 @@ Description: >
 
 Globals:
   Function:
-    Timeout: 3
+    Timeout: 900
+    MemorySize: 320
 
 Resources:
   S3SynapseLambdaExecute:

--- a/template.yaml
+++ b/template.yaml
@@ -3,11 +3,6 @@ Transform: AWS::Serverless-2016-10-31
 Description: >
   S3 Synapse sync lambda
 
-Globals:
-  Function:
-    Timeout: 900
-    MemorySize: 320
-
 Resources:
   S3SynapseLambdaExecute:
     Type: AWS::IAM::ManagedPolicy
@@ -49,6 +44,8 @@ Resources:
       Handler: lambda_function.lambda_handler
       Runtime: python3.6
       Role: !GetAtt FunctionRole.Arn
+      Timeout: 900
+      MemorySize: 320
 
   FunctionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
- Added code to compute MD5 of S3 objects

We may need to increase the timeout and memory allocated to the lambda as we expect some HTAN files will be up to ~80GB (or larger?) and will need to be read to calculate the md5.