### PR TITLE
Publish to Sage serverless repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: python
 python: 3.6
 cache: pip
 env:
-  - REPO_NAME="${PWD##*/}"
-  - LAMBDA_BUCKET="essentials-awss3lambdaartifactsbucket-x29ftznj6pqw"
-  - CFN_BUCKET="bootstrap-awss3cloudformationbucket-19qromfd235z9"
+  global:
+    - REPO_NAME="${PWD##*/}"
+    - LAMBDA_BUCKET="essentials-awss3lambdaartifactsbucket-x29ftznj6pqw"
+    - CFN_BUCKET="bootstrap-awss3cloudformationbucket-19qromfd235z9"
 install:
   - pip install pipenv
   - pipenv install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python: 3.6
 cache: pip
 env:
   - REPO_NAME="${PWD##*/}"
+  - LAMBDA_BUCKET="essentials-awss3lambdaartifactsbucket-x29ftznj6pqw"
+  - CFN_BUCKET="bootstrap-awss3cloudformationbucket-19qromfd235z9"
 install:
   - pip install pipenv
   - pipenv install --dev
@@ -27,8 +29,9 @@ jobs:
         - sam build
         - |
           sam package --template-file .aws-sam/build/template.yaml \
-            --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw \
+            --s3-bucket $LAMBDA_BUCKET \
             --output-template-file .aws-sam/build/$REPO_NAME.yaml
-        - aws s3 cp .aws-sam/build/$REPO_NAME.yaml s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/$REPO_NAME/$TRAVIS_BRANCH/
-        - aws s3 cp s3-synapse-sync-bucket.j2 s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/$REPO_NAME/$TRAVIS_BRANCH/
-        - aws s3 cp s3-synapse-sync-kms-key.yaml s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/$REPO_NAME/$TRAVIS_BRANCH/
+        - sam publish --template .aws-sam/build/$REPO_NAME.yaml
+        - aws s3 cp .aws-sam/build/$REPO_NAME.yaml s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/
+        - aws s3 cp s3-synapse-sync-bucket.j2 s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/
+        - aws s3 cp s3-synapse-sync-kms-key.yaml s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/

--- a/template.yaml
+++ b/template.yaml
@@ -1,7 +1,23 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: >
-  S3 Synapse sync lambda
+Description: >-
+  Lambda function code to index files in S3 buckets by creating filehandles
+  on Synapse, triggered by file changes to S3."
+
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: "s3-synapse-sync"
+    Description: >-
+      Lambda function code to index files in S3 buckets by creating filehandles
+      on Synapse, triggered by file changes to S3."
+    Author: "Sage-Bionetworks"
+    SpdxLicenseId: "Apache-2.0"
+    LicenseUrl: "LICENSE"
+    ReadmeUrl: "README.md"
+    Labels: ["serverless", "synapse", "storage", "S3"]
+    HomePageUrl: "https://github.com/Sage-Bionetworks/s3-synapse-sync"
+    SemanticVersion: "0.0.1"
+    SourceCodeUrl: "https://github.com/Sage-Bionetworks-IT/s3-synapse-sync/tree/0.0.1"
 
 Parameters:
   BucketVariables:


### PR DESCRIPTION
Refactor CI build to publish lambda to the Sage serverless repository.
Once in the Sage repository we can, if we choose, to make it available in
the global AWS serverless app repository[1].

[1] https://serverlessrepo.aws.amazon.com/applications