### PR TITLE
grant DSA object read access

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ parameters:
     }
   KmsDecryptPolicyArn: !stack_output_external "s3-synapse-sync-kms-key::KmsDecryptPolicyArn"
   BucketNamePrefix: "htan-dcc-*"
+  ObjectReadAccounts: “id=123456789012,emailAddress=user1@example.com” # by default Synapse and the DSA will be given read access to objects in the bucket
 ```
 
 Install the lambda using sceptre:

--- a/s3_synapse_sync/lambda_function.py
+++ b/s3_synapse_sync/lambda_function.py
@@ -73,8 +73,8 @@ def create_filehandle(syn, event, filename, bucket, key, project_id):
         contentType = mimetypes.guess_type(filename, strict=False)[0]
         storage_id = syn.restGET("/projectSettings/"+project_id+"/type/upload")['locations'][0]
 
-        synapse_canonical_id = _get_env_var('SYNAPSE_CANONICAL_ID')
-        boto3.resource('s3').ObjectAcl(bucket, key).put(GrantRead='id='+synapse_canonical_id)
+        object_read_accs = _get_env_var('OBJECT_READ_ACCOUNTS')
+        boto3.resource('s3').ObjectAcl(bucket, key).put(GrantRead=object_read_accs)
 
         fileHandle = {'concreteType': 'org.sagebionetworks.repo.model.file.S3FileHandle',
                             'fileName'    : filename,

--- a/template.yaml
+++ b/template.yaml
@@ -29,6 +29,12 @@ Parameters:
   BucketNamePrefix:
     Description: 'Prefix of buckets accessed by the lambda'
     Type: String
+  SynapseCanonicalId:
+    Type: String
+    Description: The Synapse AWS account canonical ID
+    Default: "d9df08ac799f2859d42a588b415111314cf66d0ffd072195f33b921db966b440"
+    ConstraintDescription: >-
+      Must be the canonical ID for the AWS Synapse account
   ObjectReadAccounts:
     Type: String
     Description: AWS account canonical IDs or email addresses to be granted object read permission
@@ -81,6 +87,7 @@ Resources:
       Environment:
         Variables:
           BUCKET_VARIABLES: !Ref BucketVariables
+          SYNAPSE_CANONICAL_ID: !Ref SynapseCanonicalId
           OBJECT_READ_ACCOUNTS: !Ref ObjectReadAccounts
       Timeout: 900
       MemorySize: 320

--- a/template.yaml
+++ b/template.yaml
@@ -29,12 +29,13 @@ Parameters:
   BucketNamePrefix:
     Description: 'Prefix of buckets accessed by the lambda'
     Type: String
-  SynapseCanonicalId:
+  ObjectReadAccounts:
     Type: String
-    Description: The Synapse AWS account canonical ID
-    Default: "d9df08ac799f2859d42a588b415111314cf66d0ffd072195f33b921db966b440"
+    Description: AWS account canonical IDs or email addresses to be granted object read permission
+    Default: "id=d9df08ac799f2859d42a588b415111314cf66d0ffd072195f33b921db966b440,emailaddress=dagutman@gmail.com"
     ConstraintDescription: >-
-      Must be the canonical ID for the AWS Synapse account
+      List of AWS canonical IDs or emails separated by commas
+      (e.g. id=123456789012,emailAddress=user1@example.com)
 
 Resources:
   S3SynapseLambdaExecute:
@@ -80,7 +81,7 @@ Resources:
       Environment:
         Variables:
           BUCKET_VARIABLES: !Ref BucketVariables
-          SYNAPSE_CANONICAL_ID: !Ref SynapseCanonicalId
+          OBJECT_READ_ACCOUNTS: !Ref ObjectReadAccounts
       Timeout: 900
       MemorySize: 320
 


### PR DESCRIPTION
Update lambda to set the object ACL, granting the Digital Slide Archive AWS account (in addition to Synapse) read access
