### PR TITLE
Remove deployment to serverless repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ jobs:
           sam package --template-file .aws-sam/build/template.yaml \
             --s3-bucket $LAMBDA_BUCKET \
             --output-template-file .aws-sam/build/$REPO_NAME.yaml
-        - sam publish --template .aws-sam/build/$REPO_NAME.yaml
         - aws s3 cp .aws-sam/build/$REPO_NAME.yaml s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/
         - aws s3 cp s3-synapse-sync-bucket.j2 s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/
         - aws s3 cp s3-synapse-sync-kms-key.yaml s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/

--- a/template.yaml
+++ b/template.yaml
@@ -4,21 +4,6 @@ Description: >-
   Lambda function code to index files in S3 buckets by creating filehandles
   on Synapse, triggered by file changes to S3."
 
-Metadata:
-  AWS::ServerlessRepo::Application:
-    Name: "s3-synapse-sync"
-    Description: >-
-      Lambda function code to index files in S3 buckets by creating filehandles
-      on Synapse, triggered by file changes to S3."
-    Author: "Sage-Bionetworks"
-    SpdxLicenseId: "Apache-2.0"
-    LicenseUrl: "LICENSE"
-    ReadmeUrl: "README.md"
-    Labels: ["serverless", "synapse", "storage", "S3"]
-    HomePageUrl: "https://github.com/Sage-Bionetworks/s3-synapse-sync"
-    SemanticVersion: "1.3.0"
-    SourceCodeUrl: "https://github.com/Sage-Bionetworks/s3-synapse-sync/tree/1.3.0"
-
 Parameters:
   BucketVariables:
     Description: 'String mapping buckets to Synapse project IDs'


### PR DESCRIPTION
This essentially reverts PR #19.  This lambda has become too HTAN specific
to be generally usable therfore no need to make available in serverless
repo.  Also it's a PITA to manage.