### PR TITLE
Grant admins with `s3:GetBucketPolicy`

### DIFF
--- a/s3-synapse-sync-bucket.j2
+++ b/s3-synapse-sync-bucket.j2
@@ -178,6 +178,7 @@ Resources:
             Action:
               - "s3:ListBucket*"
               - "s3:GetBucketLocation"
+              - "s3:GetBucketPolicy"
             Resource: !GetAtt S3Bucket.Arn
 
 


### PR DESCRIPTION
Depends on #41

This PR will grant admins with `s3:GetBucketPolicy`, which users already have access to. 