### PR TITLE
fix SAM build failure

### DIFF
--- a/s3_synapse_sync/requirements.txt
+++ b/s3_synapse_sync/requirements.txt
@@ -1,2 +1,2 @@
 synapseclient>=2.1,<3
-pyyaml
+pyyaml>=5.4,<6


### PR DESCRIPTION
SAM build command was failing..

```
$ sam build
Building function 'Function'
Running PythonPipBuilder:ResolveDependencies
Build Failed
Error: PythonPipBuilder:ResolveDependencies - {pyyaml==6.0(wheel), cryptography==35.0.0(wheel), cffi==1.15.0(wheel)}
The command "sam build" exited with 1.
```

This is probably because something changed with SAM that it
expected better defined dependencies.