### PR TITLE
fix SAM build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - LAMBDA_BUCKET="essentials-awss3lambdaartifactsbucket-x29ftznj6pqw"
     - CFN_BUCKET="bootstrap-awss3cloudformationbucket-19qromfd235z9"
 install:
+  - pip install wheel
   - pip install pipenv
   - pipenv install --dev
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip

--- a/s3_synapse_sync/requirements.txt
+++ b/s3_synapse_sync/requirements.txt
@@ -1,2 +1,2 @@
 synapseclient>=2.1,<3
-pyyaml
+pyyaml>=5.4,<6


### PR DESCRIPTION
SAM build command was failing..

```
$ sam build
Building function 'Function'
Running PythonPipBuilder:ResolveDependencies
Build Failed
Error: PythonPipBuilder:ResolveDependencies - {pyyaml==6.0(wheel), cryptography==35.0.0(wheel), cffi==1.15.0(wheel)}
The command "sam build" exited with 1.
```

This is due to some change with wheels[1].  We attempt to pip
install wheel as a fix.

[1] https://github.com/aws/aws-lambda-builders/issues/280