### PR TITLE
Switch to `BucketOwnerEnforced` to obviate the need for `--acl bucket-owner-full-control` on uploads

### DIFF
--- a/s3-synapse-sync-bucket.j2
+++ b/s3-synapse-sync-bucket.j2
@@ -74,7 +74,7 @@ Resources:
             MaxAge: 3000
       OwnershipControls:
         Rules:
-          - ObjectOwnership: BucketOwnerPreferred
+          - ObjectOwnership: BucketOwnerEnforced
        # LambdaBucketPermission must be setup before NotificationConfiguration
        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html
     {% if sceptre_user_data.EnableNotificationConfiguration.lower() == 'true' %}
@@ -127,14 +127,6 @@ Resources:
               - "s3:*MultipartUpload*"
             Resource: !Sub "${S3Bucket.Arn}/*"
           -
-            Sid: "BucketPolicyAccess"
-            Effect: "Allow"
-            Principal:
-              AWS: !Ref S3UserARNs
-            Action:
-              - "s3:GetBucketPolicy"
-            Resource: !GetAtt S3Bucket.Arn
-          -
             Sid: "LambdaAccess"
             Effect: Allow
             Principal:
@@ -144,16 +136,6 @@ Resources:
               - s3:PutObject
               - s3:PutObjectAcl
             Resource: !Sub "${S3Bucket.Arn}/*"
-          -
-            Sid: "Require canonical ID on object updates"
-            Effect: Deny
-            Principal:
-              AWS: !Ref S3UserARNs
-            Action: s3:PutObject
-            Resource: !Sub "${S3Bucket.Arn}/*"
-            Condition:
-              StringNotEquals:
-                s3:x-amz-acl: bucket-owner-full-control
           -
             Sid: "DenyDeleteObject"
             Effect: Deny
@@ -178,7 +160,6 @@ Resources:
             Action:
               - "s3:ListBucket*"
               - "s3:GetBucketLocation"
-              - "s3:GetBucketPolicy"
             Resource: !GetAtt S3Bucket.Arn
 
 

--- a/s3-synapse-sync-bucket.j2
+++ b/s3-synapse-sync-bucket.j2
@@ -178,7 +178,6 @@ Resources:
         Bucket: !Ref S3Bucket
         Key: owner.txt
         ContentType: text
-        ACL: authenticated-read
       Body: !Sub
         - "${list}"
         - list: !Join [",",!Ref "SynapseIDs"]


### PR DESCRIPTION
AWS recently [announced](https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-s3-object-ownership-simplify-access-management-data-s3/) the `BucketOwnerEnforced` object ownership setting. One major benefit of switching to `BucketOwnerEnforced` is that objects automatically become owned by the bucket owner (_i.e._ scicomp) without the uploader having to use `--acl bucket-owner-full-control`. This is a much nicer user experience because omission of the `--acl` option results in a cryptic `Access Denied` error. 

The same change was successfully [introduced](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/pull/82) for nextflow-infra. 

As per AWS' [recommendations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html#object-ownership-considerations), I reviewed the ACLs for all objects across all HTAN buckets using the script included below. I was looking for any object ACLs that deviated from the norm (_i.e._ granting scicomp full control). This is recommended because `BucketOwnerEnforced` will disable object ACLs, and I wanted to make sure that HTAN contributors aren't using object ACLs for sharing data with collaborators. 

The only objects with ACLs are the `owner.txt` files for linking the bucket to Synapse, which I think can be safely dropped (the relevant line is deleted in this PR). There were a few objects whose ACLs I couldn't access, but they were either "S3 folders" or objects that didn't seem important. See [object-acls.txt](https://github.com/Sage-Bionetworks/s3-synapse-sync/files/7721208/object-acls.txt) for the script output. 

Note that I'm sneaking in two small changes related to `s3:GetBucketPolicy` because it turns out that IAM identities that are outside of the bucket owner account cannot retrieve the bucket policy. 

## Python Script

```python
import boto3
from botocore.exceptions import ClientError

HTAN_BUCKETS = [
    "htan-dcc-chop",
    "htan-dcc-dfci",
    "htan-dcc-duke",
    "htan-dcc-hms",
    "htan-dcc-msk",
    "htan-dcc-ohsu",
    "htan-dcc-pcapp",
    "htan-dcc-stanford",
    "htan-dcc-tma-tnp",
    "htan-dcc-tnp-sardana",
    "htan-dcc-vanderbilt",
]


def get_matching_s3_objects(bucket, prefix="", suffix=""):
    """
    Generate objects in an S3 bucket.

    :param bucket: Name of the S3 bucket.
    :param prefix: Only fetch objects whose key starts with
        this prefix (optional).
    :param suffix: Only fetch objects whose keys end with
        this suffix (optional).
    """
    s3 = boto3.client("s3")
    paginator = s3.get_paginator("list_objects_v2")

    kwargs = {"Bucket": bucket}

    # We can pass the prefix directly to the S3 API.  If the user has passed
    # a tuple or list of prefixes, we go through them one by one.
    if isinstance(prefix, str):
        prefixes = (prefix,)
    else:
        prefixes = prefix

    for key_prefix in prefixes:
        kwargs["Prefix"] = key_prefix

        for page in paginator.paginate(**kwargs):
            try:
                contents = page["Contents"]
            except KeyError:
                break

            for obj in contents:
                key = obj["Key"]
                if key.endswith(suffix):
                    yield obj


def get_matching_s3_keys(bucket, prefix="", suffix=""):
    """
    Generate the keys in an S3 bucket.

    :param bucket: Name of the S3 bucket.
    :param prefix: Only fetch keys that start with this prefix (optional).
    :param suffix: Only fetch keys that end with this suffix (optional).
    """
    for obj in get_matching_s3_objects(bucket, prefix, suffix):
        yield obj["Key"]


s3 = boto3.client("s3")
with open("object-acls.txt", "w") as outfile:
    for bucket in HTAN_BUCKETS:
        keys = get_matching_s3_keys(bucket)
        for key in keys:
            uri = f"s3://{bucket}/{key}"
            print(uri)
            try:
                acl = s3.get_object_acl(Bucket=bucket, Key=key)
            except ClientError as e:
                outfile.write(uri)
                outfile.write("\n")
                outfile.write(str(e))
                outfile.write("\n\n")
                continue
            grants = acl["Grants"]
            for grant in grants:
                display_name = grant["Grantee"].get("DisplayName")
                if display_name != "aws.scicomp":
                    outfile.write(uri)
                    outfile.write("\n")
                    outfile.write(str(acl))
                    outfile.write("\n\n")
        outfile.flush()

```