### PR TITLE
Allow admins to access bucket policies

### DIFF
--- a/s3-synapse-sync-bucket.j2
+++ b/s3-synapse-sync-bucket.j2
@@ -160,6 +160,7 @@ Resources:
             Action:
               - "s3:ListBucket*"
               - "s3:GetBucketLocation"
+              - "s3:GetBucketPolicy"
             Resource: !GetAtt S3Bucket.Arn
 
 

--- a/s3-synapse-sync-bucket.j2
+++ b/s3-synapse-sync-bucket.j2
@@ -158,9 +158,7 @@ Resources:
             Principal:
               AWS: !Ref S3AdminARNs
             Action:
-              - "s3:ListBucket*"
-              - "s3:GetBucketLocation"
-              - "s3:GetBucketPolicy"
+              - s3:*
             Resource: !GetAtt S3Bucket.Arn
 
 


### PR DESCRIPTION
This will help debug S3 access issues by confirming that the policy is formatted as expected. 