### PR TITLE
[IT-4152] Resolve Security hub 2.1.5.2 finding

### DIFF
--- a/s3-synapse-sync-bucket.j2
+++ b/s3-synapse-sync-bucket.j2
@@ -94,6 +94,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       CorsConfiguration:
         CorsRules:
           - Id: SynapseCORSRule


### PR DESCRIPTION
Security hub will report finding
`2.1.5.2 S3 Block Public Access setting should be enabled at the bucket-level` 
if `Block all public access` is not enabled on non-public buckets.
We enable that configuration for synapse buckets.